### PR TITLE
Fix npm URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![devDependency Status](http://img.shields.io/david/dev/alexgorbatchev/node-crc.svg?style=flat)](https://david-dm.org/alexgorbatchev/node-crc#info=devDependencies)
 [![Build Status](http://img.shields.io/travis/alexgorbatchev/node-crc.svg?style=flat&branch=master)](https://travis-ci.org/alexgorbatchev/node-crc)
 
-[![NPM](https://nodei.co/npm/crc.svg?style=flat)](https://npmjs.org/package/node-crc)
+[![NPM](https://nodei.co/npm/crc.svg?style=flat)](https://npmjs.org/package/crc)
 
 Module for calculating Cyclic Redundancy Check (CRC).
 


### PR DESCRIPTION
The npm URL in the README was pointing to https://www.npmjs.com/package/node-crc which is broken. Pointing to https://www.npmjs.com/package/crc works.