### PR TITLE
Move required modules from devDependencies to Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,15 @@
     "name": "Alex Gorbatchev",
     "url": "https://github.com/alexgorbatchev"
   },
-  "devDependencies": {
+  "dependencies": {
     "babel-cli": "^6.3.15",
     "babel-core": "^6.1.21",
     "babel-preset-es2015": "^6.1.18",
+    "buffer-crc32": "^0.2.3"
+  },
+  "devDependencies": {
     "beautify-benchmark": "^0.2.4",
     "benchmark": "^1.0.0",
-    "buffer-crc32": "^0.2.3",
     "chai": "^3.4.1",
     "mocha": "*",
     "seedrandom": "^2.3.6"


### PR DESCRIPTION
This allows the module to work on systems that don't have babel or babel-preset-es2015 installed already.

The test suite passes locally. Let me know if you have any questions or if there is anything else I need to do before submitting a PR.