### PR TITLE
Use new Buffer() to remove deprecation warnings

### DIFF
--- a/lib/crc1.js
+++ b/lib/crc1.js
@@ -9,9 +9,9 @@ var _define_crc2 = _interopRequireDefault(_define_crc);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 module.exports = (0, _define_crc2.default)('crc1', function (buf, previous) {
-  if (!_buffer.Buffer.isBuffer(buf)) buf = (0, _buffer.Buffer)(buf);
+  if (!_buffer.Buffer.isBuffer(buf)) buf = new _buffer.Buffer(buf);
 
-  var crc = ~ ~previous;
+  var crc = ~~previous;
   var accum = 0;
 
   for (var index = 0; index < buf.length; index++) {

--- a/lib/crc16.js
+++ b/lib/crc16.js
@@ -14,9 +14,9 @@ var TABLE = [0x0000, 0xc0c1, 0xc181, 0x0140, 0xc301, 0x03c0, 0x0280, 0xc241, 0xc
 if (typeof Int32Array !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = (0, _define_crc2.default)('crc-16', function (buf, previous) {
-  if (!_buffer.Buffer.isBuffer(buf)) buf = (0, _buffer.Buffer)(buf);
+  if (!_buffer.Buffer.isBuffer(buf)) buf = new _buffer.Buffer(buf);
 
-  var crc = ~ ~previous;
+  var crc = ~~previous;
 
   for (var index = 0; index < buf.length; index++) {
     var byte = buf[index];

--- a/lib/crc16_ccitt.js
+++ b/lib/crc16_ccitt.js
@@ -14,9 +14,9 @@ var TABLE = [0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7, 0x8
 if (typeof Int32Array !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = (0, _define_crc2.default)('ccitt', function (buf, previous) {
-  if (!_buffer.Buffer.isBuffer(buf)) buf = (0, _buffer.Buffer)(buf);
+  if (!_buffer.Buffer.isBuffer(buf)) buf = new _buffer.Buffer(buf);
 
-  var crc = typeof previous !== 'undefined' ? ~ ~previous : 0xffff;
+  var crc = typeof previous !== 'undefined' ? ~~previous : 0xffff;
 
   for (var index = 0; index < buf.length; index++) {
     var byte = buf[index];

--- a/lib/crc16_kermit.js
+++ b/lib/crc16_kermit.js
@@ -14,9 +14,9 @@ var TABLE = [0x0000, 0x1189, 0x2312, 0x329b, 0x4624, 0x57ad, 0x6536, 0x74bf, 0x8
 if (typeof Int32Array !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = (0, _define_crc2.default)('kermit', function (buf, previous) {
-  if (!_buffer.Buffer.isBuffer(buf)) buf = (0, _buffer.Buffer)(buf);
+  if (!_buffer.Buffer.isBuffer(buf)) buf = new _buffer.Buffer(buf);
 
-  var crc = typeof previous !== 'undefined' ? ~ ~previous : 0x0000;
+  var crc = typeof previous !== 'undefined' ? ~~previous : 0x0000;
 
   for (var index = 0; index < buf.length; index++) {
     var byte = buf[index];

--- a/lib/crc16_modbus.js
+++ b/lib/crc16_modbus.js
@@ -14,9 +14,9 @@ var TABLE = [0x0000, 0xc0c1, 0xc181, 0x0140, 0xc301, 0x03c0, 0x0280, 0xc241, 0xc
 if (typeof Int32Array !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = (0, _define_crc2.default)('crc-16-modbus', function (buf, previous) {
-  if (!_buffer.Buffer.isBuffer(buf)) buf = (0, _buffer.Buffer)(buf);
+  if (!_buffer.Buffer.isBuffer(buf)) buf = new _buffer.Buffer(buf);
 
-  var crc = typeof previous !== 'undefined' ? ~ ~previous : 0xffff;
+  var crc = typeof previous !== 'undefined' ? ~~previous : 0xffff;
 
   for (var index = 0; index < buf.length; index++) {
     var byte = buf[index];

--- a/lib/crc16_xmodem.js
+++ b/lib/crc16_xmodem.js
@@ -9,9 +9,9 @@ var _define_crc2 = _interopRequireDefault(_define_crc);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 module.exports = (0, _define_crc2.default)('xmodem', function (buf, previous) {
-  if (!_buffer.Buffer.isBuffer(buf)) buf = (0, _buffer.Buffer)(buf);
+  if (!_buffer.Buffer.isBuffer(buf)) buf = new _buffer.Buffer(buf);
 
-  var crc = typeof previous !== 'undefined' ? ~ ~previous : 0x0;
+  var crc = typeof previous !== 'undefined' ? ~~previous : 0x0;
 
   for (var index = 0; index < buf.length; index++) {
     var byte = buf[index];

--- a/lib/crc24.js
+++ b/lib/crc24.js
@@ -14,9 +14,9 @@ var TABLE = [0x000000, 0x864cfb, 0x8ad50d, 0x0c99f6, 0x93e6e1, 0x15aa1a, 0x1933e
 if (typeof Int32Array !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = (0, _define_crc2.default)('crc-24', function (buf, previous) {
-  if (!_buffer.Buffer.isBuffer(buf)) buf = (0, _buffer.Buffer)(buf);
+  if (!_buffer.Buffer.isBuffer(buf)) buf = new _buffer.Buffer(buf);
 
-  var crc = typeof previous !== 'undefined' ? ~ ~previous : 0xb704ce;
+  var crc = typeof previous !== 'undefined' ? ~~previous : 0xb704ce;
 
   for (var index = 0; index < buf.length; index++) {
     var byte = buf[index];

--- a/lib/crc32.js
+++ b/lib/crc32.js
@@ -14,9 +14,9 @@ var TABLE = [0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af
 if (typeof Int32Array !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = (0, _define_crc2.default)('crc-32', function (buf, previous) {
-  if (!_buffer.Buffer.isBuffer(buf)) buf = (0, _buffer.Buffer)(buf);
+  if (!_buffer.Buffer.isBuffer(buf)) buf = new _buffer.Buffer(buf);
 
-  var crc = previous === 0 ? 0 : ~ ~previous ^ -1;
+  var crc = previous === 0 ? 0 : ~~previous ^ -1;
 
   for (var index = 0; index < buf.length; index++) {
     var byte = buf[index];

--- a/lib/crc8.js
+++ b/lib/crc8.js
@@ -14,9 +14,9 @@ var TABLE = [0x00, 0x07, 0x0e, 0x09, 0x1c, 0x1b, 0x12, 0x15, 0x38, 0x3f, 0x36, 0
 if (typeof Int32Array !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = (0, _define_crc2.default)('crc-8', function (buf, previous) {
-  if (!_buffer.Buffer.isBuffer(buf)) buf = (0, _buffer.Buffer)(buf);
+  if (!_buffer.Buffer.isBuffer(buf)) buf = new _buffer.Buffer(buf);
 
-  var crc = ~ ~previous;
+  var crc = ~~previous;
 
   for (var index = 0; index < buf.length; index++) {
     var byte = buf[index];

--- a/lib/crc8_1wire.js
+++ b/lib/crc8_1wire.js
@@ -14,9 +14,9 @@ var TABLE = [0x00, 0x5e, 0xbc, 0xe2, 0x61, 0x3f, 0xdd, 0x83, 0xc2, 0x9c, 0x7e, 0
 if (typeof Int32Array !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = (0, _define_crc2.default)('dallas-1-wire', function (buf, previous) {
-  if (!_buffer.Buffer.isBuffer(buf)) buf = (0, _buffer.Buffer)(buf);
+  if (!_buffer.Buffer.isBuffer(buf)) buf = new _buffer.Buffer(buf);
 
-  var crc = ~ ~previous;
+  var crc = ~~previous;
 
   for (var index = 0; index < buf.length; index++) {
     var byte = buf[index];

--- a/src/crc1.js
+++ b/src/crc1.js
@@ -2,7 +2,7 @@ import {Buffer} from 'buffer';
 import defineCrc from './define_crc';
 
 module.exports = defineCrc('crc1', function (buf, previous) {
-  if (!Buffer.isBuffer(buf)) buf = Buffer(buf);
+  if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
 
   let crc = ~~previous;
   let accum = 0;

--- a/src/crc16.js
+++ b/src/crc16.js
@@ -40,7 +40,7 @@ let TABLE = [
 if (typeof(Int32Array) !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = defineCrc('crc-16', function (buf, previous) {
-  if (!Buffer.isBuffer(buf)) buf = Buffer(buf);
+  if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
 
   let crc = ~~previous;
 

--- a/src/crc16_ccitt.js
+++ b/src/crc16_ccitt.js
@@ -40,7 +40,7 @@ let TABLE = [
 if (typeof(Int32Array) !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = defineCrc('ccitt', function (buf, previous) {
-  if (!Buffer.isBuffer(buf)) buf = Buffer(buf);
+  if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
 
   let crc = typeof(previous) !== 'undefined' ? ~~previous : 0xffff;
 

--- a/src/crc16_kermit.js
+++ b/src/crc16_kermit.js
@@ -40,7 +40,7 @@ let TABLE = [
 if (typeof(Int32Array) !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = defineCrc('kermit', function (buf, previous) {
-  if (!Buffer.isBuffer(buf)) buf = Buffer(buf);
+  if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
 
   let crc = typeof(previous) !== 'undefined' ? ~~previous : 0x0000;
 

--- a/src/crc16_modbus.js
+++ b/src/crc16_modbus.js
@@ -40,7 +40,7 @@ let TABLE = [
 if (typeof(Int32Array) !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = defineCrc('crc-16-modbus', function (buf, previous) {
-  if (!Buffer.isBuffer(buf)) buf = Buffer(buf);
+  if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
 
   let crc = typeof(previous) !== 'undefined' ? ~~previous : 0xffff;
 

--- a/src/crc16_xmodem.js
+++ b/src/crc16_xmodem.js
@@ -2,7 +2,7 @@ import {Buffer} from 'buffer';
 import defineCrc from './define_crc';
 
 module.exports = defineCrc('xmodem', function (buf, previous) {
-  if (!Buffer.isBuffer(buf)) buf = Buffer(buf);
+  if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
 
   let crc = typeof(previous) !== 'undefined' ? ~~previous : 0x0;
 

--- a/src/crc24.js
+++ b/src/crc24.js
@@ -40,7 +40,7 @@ let TABLE = [
 if (typeof(Int32Array) !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = defineCrc('crc-24', function (buf, previous) {
-  if (!Buffer.isBuffer(buf)) buf = Buffer(buf);
+  if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
 
   let crc = typeof(previous) !== 'undefined' ? ~~previous : 0xb704ce;
 

--- a/src/crc32.js
+++ b/src/crc32.js
@@ -72,7 +72,7 @@ let TABLE = [
 if (typeof(Int32Array) !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = defineCrc('crc-32', function (buf, previous) {
-  if (!Buffer.isBuffer(buf)) buf = Buffer(buf);
+  if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
 
   let crc = previous === 0 ? 0 : ~~previous ^ -1
 

--- a/src/crc8.js
+++ b/src/crc8.js
@@ -24,7 +24,7 @@ let TABLE = [
 if (typeof(Int32Array) !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = defineCrc('crc-8', function (buf, previous) {
-  if (!Buffer.isBuffer(buf)) buf = Buffer(buf);
+  if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
 
   let crc = ~~previous;
 

--- a/src/crc8_1wire.js
+++ b/src/crc8_1wire.js
@@ -24,7 +24,7 @@ let TABLE = [
 if (typeof(Int32Array) !== 'undefined') TABLE = new Int32Array(TABLE);
 
 module.exports = defineCrc('dallas-1-wire', function (buf, previous) {
-  if (!Buffer.isBuffer(buf)) buf = Buffer(buf);
+  if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
 
   let crc = ~~previous;
 


### PR DESCRIPTION
The latest node versions start to print deprecation warnings when `Buffer` is called as a function. This is far from urgent (I don't think there was an official release including that change) but I thought it couldn't hurt to make this change already. :)

There's also an unrelated test failure but that might very well be resolved once that node branch stabilizes. For now I just ignored it. FYI:

```
  1) CRC16 BUFFER: AR0AAAGP2KJc/vg/AAAAErgGAK8dAAgLAQAA should calculate a checksum for multiple data

      Uncaught AssertionError: expected '7d4c' to equal 'f57c'
      + expected - actual

      -7d4c
      +f57c

      at test/test_helpers.js:79:30
      at test/test_helpers.js:27:7
      at ChildProcess.exithandler (child_process.js:202:7)
      at maybeClose (internal/child_process.js:877:16)
      at Socket.<anonymous> (internal/child_process.js:334:11)
      at Pipe._handle.close [as _onclose] (net.js:493:12)
```