### PR TITLE
Edits webpack test to cause failure in version 3.6.0

### DIFF
--- a/webpack-test/index.js
+++ b/webpack-test/index.js
@@ -1,4 +1,4 @@
-import crc32 from 'crc/crc32';
+import crc from 'crc';
 
 // eslint-disable-next-line no-console
-console.log(crc32('hello world'));
+console.log(crc.crc32('hello world'));


### PR DESCRIPTION
So below are the edits that will cause the webpack failure. This import method worked in the previous version (as shown in https://github.com/stellar/js-stellar-base/blob/master/src/strkey.js) but now it results in an undefined object.